### PR TITLE
feat(compression): Add initial Deflate encoding support

### DIFF
--- a/Paracord.Core.Tests/Compression/DeflateCompressionProvider/CompressTests.cs
+++ b/Paracord.Core.Tests/Compression/DeflateCompressionProvider/CompressTests.cs
@@ -1,0 +1,44 @@
+using System.Text;
+
+using Paracord.Core.Compression;
+
+namespace Paracord.Core.Tests.Compression.DeflateCompressionProviderTests
+{
+    public class CompressTests
+    {
+        [Fact]
+        public void CompressReturnsEmptyArrayGivenEmptyStream()
+        {
+            // Arrange
+            MemoryStream inputStream = new MemoryStream();
+
+            // Act
+            byte[] compressed = new DeflateCompressionProvider().Compress(inputStream);
+
+            // Assert
+            compressed.Length.Should().Be(0);
+        }
+
+        [Fact]
+        public void CompressReturnsCompressedStringGivenStreamWithStringContent()
+        {
+            // Arrange
+            string content = "This is a test string!";
+
+            MemoryStream inputStream = new MemoryStream(Encoding.ASCII.GetBytes(content));
+
+            // Act
+            byte[] compressed = new DeflateCompressionProvider().Compress(inputStream);
+
+            // Assert
+            compressed.Should().NotBeEmpty();
+            compressed.Should().HaveCount(22);
+            compressed.Should().BeEquivalentTo(new byte[]
+            {
+                0x0B, 0xC9, 0xC8, 0x2C, 0x56, 0x00, 0xA2, 0x44, 0x85, 0x92,
+                0xD4, 0xE2, 0x12, 0x85, 0xE2, 0x92, 0xA2, 0xCC, 0xBC, 0x74,
+                0x45, 0x00
+            });
+        }
+    }
+}

--- a/Paracord.Core.Tests/Compression/DeflateCompressionProvider/DecompressTests.cs
+++ b/Paracord.Core.Tests/Compression/DeflateCompressionProvider/DecompressTests.cs
@@ -1,0 +1,38 @@
+using System.Text;
+
+using Paracord.Core.Compression;
+
+namespace Paracord.Core.Tests.Compression.DeflateCompressionProviderTests
+{
+    public class DecompressTests
+    {
+        [Fact]
+        public void DecompressReturnsEmptyArrayGivenEmptyStream()
+        {
+            // Arrange
+            MemoryStream inputStream = new MemoryStream();
+
+            // Act
+            byte[] decompressed = new DeflateCompressionProvider().Decompress(inputStream);
+
+            // Assert
+            decompressed.Length.Should().Be(0);
+        }
+
+        [Fact]
+        public void DecompressReturnsSameAsInputGivenStringContent()
+        {
+            // Arrange
+            string content = "This is a test string!";
+
+            MemoryStream inputStream = new MemoryStream(Encoding.ASCII.GetBytes(content));
+
+            // Act
+            byte[] compressed = new DeflateCompressionProvider().Compress(new MemoryStream(Encoding.ASCII.GetBytes(content)));
+            byte[] decompressed = new DeflateCompressionProvider().Decompress(new MemoryStream(compressed));
+
+            // Assert
+            Encoding.ASCII.GetString(decompressed.ToArray()).Should().Be(content);
+        }
+    }
+}

--- a/Paracord.Core/Compression/DeflateCompressionProvider.cs
+++ b/Paracord.Core/Compression/DeflateCompressionProvider.cs
@@ -1,0 +1,37 @@
+using System.IO.Compression;
+
+namespace Paracord.Core.Compression
+{
+    public class DeflateCompressionProvider : ICompressionProvider
+    {
+        /// <inheritdoc />
+        /// <remarks>
+        /// Expands to <c>deflate</c>.
+        /// </remarks>
+        public string AcceptedEncoding => "deflate";
+
+        public byte[] Compress(Stream inputStream)
+        {
+            using var resultStream = new MemoryStream();
+            using var compressionStream = new DeflateStream(resultStream, CompressionMode.Compress);
+
+            inputStream.Seek(0, SeekOrigin.Begin);
+            inputStream.CopyTo(compressionStream);
+            compressionStream.Close();
+
+            return resultStream.ToArray();
+        }
+
+        public byte[] Decompress(Stream inputStream)
+        {
+            using var resultStream = new MemoryStream();
+            using var compressionStream = new DeflateStream(inputStream, CompressionMode.Decompress);
+
+            inputStream.Seek(0, SeekOrigin.Begin);
+            compressionStream.CopyTo(resultStream);
+            compressionStream.Close();
+
+            return resultStream.ToArray();
+        }
+    }
+}

--- a/Paracord.Core/Listener/HttpListener.cs
+++ b/Paracord.Core/Listener/HttpListener.cs
@@ -46,6 +46,7 @@ namespace Paracord.Core.Listener
             this.RegisterMiddleware<CompressionMiddleware>();
 
             this.RegisterCompression<GzipCompressionProvider>();
+            this.RegisterCompression<DeflateCompressionProvider>();
 
             this.SslCertificate = sslCertificate;
         }


### PR DESCRIPTION
This pull-request will add support for `deflate` in `Accept-Encoding` HTTP request headers.