### PR TITLE
feat/ssl-support

### DIFF
--- a/Paracord.Core/Http/HttpRequestStream.cs
+++ b/Paracord.Core/Http/HttpRequestStream.cs
@@ -5,9 +5,9 @@ namespace Paracord.Core.Http
     public class HttpRequestStream : Stream
     {
         /// <summary>
-        /// The internal <see cref="NetworkStream" />-instance for handling TCP-sockets.
+        /// The internal <see cref="Stream" />-instance for handling TCP-sockets.
         /// </summary>
-        protected NetworkStream Stream { get; set; }
+        protected Stream Stream { get; set; }
 
         /// <summary>
         /// Indicates whether the current stream supports reading.
@@ -51,10 +51,10 @@ namespace Paracord.Core.Http
         }
 
         /// <summary>
-        /// Initialize a new <see cref="HttpRequestStream" />-instance with the specified <see cref="NetworkStream" />-instance.
+        /// Initialize a new <see cref="HttpRequestStream" />-instance with the specified <see cref="Stream" />-instance.
         /// </summary>
-        /// <param name="stream">The parent <see cref="NetworkStream" />-instance.</param>
-        public HttpRequestStream(NetworkStream stream)
+        /// <param name="stream">The parent <see cref="Stream" />-instance.</param>
+        public HttpRequestStream(Stream stream)
         {
             this.Stream = stream;
         }

--- a/Paracord.Core/Http/HttpResponseStream.cs
+++ b/Paracord.Core/Http/HttpResponseStream.cs
@@ -5,9 +5,9 @@ namespace Paracord.Core.Http
     public class HttpResponseStream : Stream
     {
         /// <summary>
-        /// The internal <see cref="NetworkStream" />-instance for handling TCP-sockets.
+        /// The internal <see cref="Stream" />-instance for handling TCP-sockets.
         /// </summary>
-        protected NetworkStream Stream { get; set; }
+        protected Stream Stream { get; set; }
 
         /// <summary>
         /// Indicates whether the current stream supports reading.
@@ -51,10 +51,10 @@ namespace Paracord.Core.Http
         }
 
         /// <summary>
-        /// Initialize a new <see cref="HttpResponseStream" />-instance with the specified <see cref="NetworkStream" />-instance.
+        /// Initialize a new <see cref="HttpResponseStream" />-instance with the specified <see cref="Stream" />-instance.
         /// </summary>
-        /// <param name="stream">The parent <see cref="NetworkStream" />-instance.</param>
-        public HttpResponseStream(NetworkStream stream)
+        /// <param name="stream">The parent <see cref="Stream" />-instance.</param>
+        public HttpResponseStream(Stream stream)
         {
             this.Stream = stream;
         }

--- a/Paracord.Core/Listener/HttpListener.cs
+++ b/Paracord.Core/Listener/HttpListener.cs
@@ -108,13 +108,7 @@ namespace Paracord.Core.Listener
         /// <returns>The parsed <see cref="HttpContext" />-object.</returns>
         protected HttpContext WrapTcpClient(TcpClient client)
         {
-            Stream stream = client.GetStream();
             HttpContext ctx = new HttpContext(this, client);
-
-            if(this.IsSecure)
-            {
-                stream = this.CreateSslStream(stream);
-            }
 
             // Reading client.Available will reset it
             int bytesExpected = 0;
@@ -124,7 +118,7 @@ namespace Paracord.Core.Listener
             while((bytesExpected = client.Available) == 0) { }
 
             Byte[] bytes = new Byte[2048];
-            bytesRead = stream.Read(bytes, 0, bytes.Length);
+            bytesRead = ctx.ConnectionStream.Read(bytes, 0, bytes.Length);
 
             // Limit bytes size
             bytes = bytes[0..bytesRead];

--- a/Paracord.Core/Listener/HttpListener.cs
+++ b/Paracord.Core/Listener/HttpListener.cs
@@ -110,11 +110,10 @@ namespace Paracord.Core.Listener
         {
             HttpContext ctx = new HttpContext(this, client);
 
-            // Reading client.Available will reset it
             int bytesExpected = 0;
             int bytesRead = 0;
 
-            // Wait until data is available
+            // Reading client.Available will reset it
             while((bytesExpected = client.Available) == 0) { }
 
             Byte[] bytes = new Byte[2048];

--- a/Paracord.Core/Listener/HttpListener.cs
+++ b/Paracord.Core/Listener/HttpListener.cs
@@ -21,16 +21,11 @@ namespace Paracord.Core.Listener
         public readonly CompressionProviderCollection CompressionProviders = new();
 
         /// <summary>
-        /// The SSL certificate to use for HTTPS connections, if enabled.
-        /// </summary>
-        protected readonly X509Certificate2? SslCertificate;
-
-        /// <summary>
         /// Whether the listener is secured with HTTPS.
         /// </summary>
-        protected bool IsSecure
+        public bool IsSecure
         {
-            get => this.SslCertificate != null;
+            get => this.Certificate != null;
         }
 
         /// <summary>
@@ -39,7 +34,7 @@ namespace Paracord.Core.Listener
         /// <param name="address">The IP-address to listen on.</param>
         /// <param name="port">The port to listen on.</param>
         /// <param name="sslCertificate">The SSL certificate to use for HTTPS connections. HTTPS is disabled, if null.</param>
-        public HttpListener(string address = "*", UInt16 port = 80, X509Certificate2? sslCertificate = null) : base(address, port)
+        public HttpListener(string address = "*", UInt16 port = 80, X509Certificate2? sslCertificate = null) : base(address, port, sslCertificate)
         {
             this.RegisterMiddleware<DateMiddleware>();
             this.RegisterMiddleware<ServerMiddleware>();
@@ -48,8 +43,6 @@ namespace Paracord.Core.Listener
             this.RegisterCompression<BrotliCompressionProvider>();
             this.RegisterCompression<DeflateCompressionProvider>();
             this.RegisterCompression<GzipCompressionProvider>();
-
-            this.SslCertificate = sslCertificate;
         }
 
         /// <inheritdoc cref="ListenerBase.Start" />

--- a/Paracord.Core/Listener/ListenerBase.cs
+++ b/Paracord.Core/Listener/ListenerBase.cs
@@ -16,7 +16,7 @@ namespace Paracord.Core.Listener
         /// <summary>
         /// An optional certificate to use for SSL connections. If null, SSL is disabled.
         /// </summary>
-        protected readonly X509Certificate2? Certificate;
+        public readonly X509Certificate2? Certificate;
 
         /// <summary>
         /// The actual TCP listener.

--- a/Paracord.Core/Listener/ListenerBase.cs
+++ b/Paracord.Core/Listener/ListenerBase.cs
@@ -133,24 +133,5 @@ namespace Paracord.Core.Listener
         /// <returns>A task, resolving to the accepted <see cref="TcpClient" />-instance.</returns>
         protected async Task<TcpClient> AcceptClientAsync()
             => await this.Listener.AcceptTcpClientAsync();
-
-        /// <summary>
-        /// Wrap the specified stream with an <see cref="SslStream" />-instance and authenticate as a server, using the <see cref="ListenerBase.Certificate" />.
-        /// </summary>
-        /// <param name="innerStream">The <see cref="Stream" />-instance to wrap in an SSL stream.</param>
-        /// <returns>The wrapped <see cref="SslStream" />-instance.</returns>
-        /// <exception cref="ArgumentNullException">The certificate, <see cref="ListenerBase.Certificate" />, is null.</exception>
-        protected SslStream CreateSslStream(Stream innerStream)
-        {
-            ArgumentNullException.ThrowIfNull(this.Certificate, nameof(this.Certificate));
-
-            lock(this.InternalLock)
-            {
-                SslStream sslStream = new SslStream(innerStream, true);
-                sslStream.AuthenticateAsServer(this.Certificate, false, SslProtocols.Tls13 | SslProtocols.Tls12, false);
-
-                return sslStream;
-            }
-        }
     }
 }


### PR DESCRIPTION
Finally add some proper SSL support.

Currently, it does not do any SSL certificate imports itself, so the supported certificate types are determined by [X509Certificate2](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2?view=net-7.0).