### PR TITLE
feat/etag-middleware

### DIFF
--- a/Paracord.Core/Http/HttpContext.cs
+++ b/Paracord.Core/Http/HttpContext.cs
@@ -142,6 +142,8 @@ namespace Paracord.Shared.Models.Http
                 throw new ObjectDisposedException("HttpContext", "The socket has been closed.");
             }
 
+            this.Listener.ExecuteMiddleware(_ => _.BeforeResponseSent(this.Listener, this.Request, this.Response), true);
+
             // Default to the length of the body.
             if(this.Response.Headers["content-length"] == null)
             {
@@ -153,8 +155,6 @@ namespace Paracord.Shared.Models.Http
             {
                 throw new InvalidDataException("Content-Length parameter doesn't match the length of the Body property on the HttpResponse.");
             }
-
-            this.Listener.ExecuteMiddleware(_ => _.BeforeResponseSent(this.Listener, this.Request, this.Response), true);
 
             byte[] responseBytes = HttpParser.SerializeResponse(this.Response);
 

--- a/Paracord.Core/Http/HttpResponse.cs
+++ b/Paracord.Core/Http/HttpResponse.cs
@@ -50,6 +50,14 @@ namespace Paracord.Core.Http
         public int ThreadId { get; private set; }
 
         /// <summary>
+        /// Whether the status code of the response is 2xx.
+        /// </summary>
+        public bool IsSuccessful
+        {
+            get => (int) this.StatusCode >= 200 && (int) this.StatusCode < 300;
+        }
+
+        /// <summary>
         /// Initialize a new <see cref="HttpResponse" />-instance.
         /// </summary>
         public HttpResponse()

--- a/Paracord.Core/Listener/HttpListener.cs
+++ b/Paracord.Core/Listener/HttpListener.cs
@@ -39,6 +39,7 @@ namespace Paracord.Core.Listener
             this.RegisterMiddleware<DateMiddleware>();
             this.RegisterMiddleware<ServerMiddleware>();
             this.RegisterMiddleware<CompressionMiddleware>();
+            this.RegisterMiddleware<ETagMiddleware>();
 
             this.RegisterCompression<BrotliCompressionProvider>();
             this.RegisterCompression<DeflateCompressionProvider>();

--- a/Paracord.Core/Middleware/ETagMiddleware.cs
+++ b/Paracord.Core/Middleware/ETagMiddleware.cs
@@ -1,0 +1,88 @@
+using System.Security.Cryptography;
+using Paracord.Core.Http;
+using Paracord.Core.Listener;
+using Paracord.Shared.Models.Http;
+
+namespace Paracord.Core.Middleware
+{
+    /// <summary>
+    /// This middleware adds the "ETag"-header to eligible responses, to aid in caching.
+    /// </summary>
+    public class ETagMiddleware : MiddlewareBase
+    {
+        /// <summary>
+        /// The maximum response size, for the response to be eligible for the "ETag"-header.
+        /// </summary>
+        /// <remarks>
+        /// Expands to 32KB (<c>= 32 * 1024</c>)
+        /// </remarks>
+        public readonly int MaximumResponseSize = 32 * 1024;
+
+        public override void BeforeResponseSent(HttpListener listener, HttpRequest request, HttpResponse response)
+        {
+            this.Next();
+
+            if(!this.IsEligible(response))
+            {
+                return;
+            }
+
+            string digest = this.ComputeDigest(response);
+            string? ifNoneMatch = response.Headers[HttpHeaders.IfNoneMatch];
+
+            response.Headers[HttpHeaders.ETag] = digest;
+
+            if(ifNoneMatch != null && ifNoneMatch != digest)
+            {
+                response.StatusCode = HttpStatusCode.PreconditionFailed;
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Whether the specified response is eligible for the "ETag"-header.
+        /// </summary>
+        /// <param name="response">The <see cref="HttpResponse" />-instance to check for.</param>
+        /// <returns>True, if the response is eligible. Otherwise, false.</returns>
+        protected bool IsEligible(HttpResponse response)
+        {
+            if(!response.IsSuccessful)
+            {
+                return false;
+            }
+
+            if(response.Headers.Get(HttpHeaders.ETag) != null)
+            {
+                return false;
+            }
+
+            if(response.ContentLength > MaximumResponseSize)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Compute the hash digest from the body of the response.
+        /// </summary>
+        /// <remarks>
+        /// The hash is generated with SHA256.
+        /// </remarks>
+        /// <param name="response">The response to compute the digest from.</param>
+        /// <returns>The digest of the body, wrapped in double-quotes.</returns>
+        protected string ComputeDigest(HttpResponse response)
+        {
+            using SHA256 sha256 = SHA256.Create();
+
+            response.Body.Seek(0, SeekOrigin.Begin);
+            byte[] digestBytes = sha256.ComputeHash(response.Body);
+
+            response.Body.Seek(0, SeekOrigin.Begin);
+            string digest = Convert.ToBase64String(digestBytes);
+
+            return $"\"{digest}\"";
+        }
+    }
+}


### PR DESCRIPTION
To aid caching resources on any intermediary proxies, `ETag` headers are now created on the response headers, when the body is relatively small (< 32KB). 