### PR TITLE
feat/https-redirect-middleware

### DIFF
--- a/Paracord.Core.IntegrationTests/Middleware/HttpsRedirectMiddlewareTests.cs
+++ b/Paracord.Core.IntegrationTests/Middleware/HttpsRedirectMiddlewareTests.cs
@@ -1,0 +1,91 @@
+using Moq;
+using Paracord.Core.Http;
+using Paracord.Core.Listener;
+using Paracord.Core.Middleware;
+using Paracord.Shared.Models.Http;
+using Paracord.Shared.Models.Listener;
+
+namespace Paracord.Core.Tests.Middleware
+{
+    public class TestHttpContext : HttpContext
+    {
+        public TestHttpContext(HttpListener listener, ListenerPrefix listenerPrefix) : base(listener, listenerPrefix)
+        {
+
+        }
+    }
+
+    public class HttpsRedirectMiddlewareTests
+    {
+        [Fact]
+        public void HttpsRedirectMiddlewareContinuesGivenSingleInsecurePrefixAndInsecureRequest()
+        {
+            // Arrange
+            HttpsRedirectMiddleware middleware = new HttpsRedirectMiddleware();
+            HttpListener listener = new HttpListener();
+            listener.Prefixes.Add("http://localhost:8080");
+
+            HttpContext context = new TestHttpContext(listener, listener.Prefixes.First());
+
+            Mock<HttpRequest> request = new Mock<HttpRequest>();
+            request.Object.Context = context;
+
+            Mock<HttpResponse> response = new Mock<HttpResponse>();
+            response.Object.Context = context;
+
+            // Act
+            middleware.AfterRequestReceived(listener, request.Object, response.Object);
+
+            // Assert
+            response.Object.StatusCode = HttpStatusCode.Ok;
+        }
+
+        [Fact]
+        public void HttpsRedirectMiddlewareContinuesGivenSingleSecurePrefixAndSecureRequest()
+        {
+            // Arrange
+            HttpsRedirectMiddleware middleware = new HttpsRedirectMiddleware();
+            HttpListener listener = new HttpListener();
+            listener.Prefixes.Add("https://localhost:8080");
+
+            HttpContext context = new TestHttpContext(listener, listener.Prefixes.First());
+
+            Mock<HttpRequest> request = new Mock<HttpRequest>();
+            request.Object.Context = context;
+
+            Mock<HttpResponse> response = new Mock<HttpResponse>();
+            response.Object.Context = context;
+
+            // Act
+            middleware.AfterRequestReceived(listener, request.Object, response.Object);
+
+            // Assert
+            response.Object.StatusCode = HttpStatusCode.Ok;
+        }
+
+        [Fact]
+        public void HttpsRedirectMiddlewareContinuesGivenSingleSecurePrefixAndInsecureRequest()
+        {
+            // Arrange
+            HttpsRedirectMiddleware middleware = new HttpsRedirectMiddleware();
+            HttpListener listener = new HttpListener();
+            listener.Prefixes.Add("https://localhost:8080");
+
+            Mock<TestHttpContext> context = new Mock<TestHttpContext>(listener, ListenerPrefix.Parse("http://localhost:8080"));
+
+            Mock<HttpRequest> request = new Mock<HttpRequest>();
+            request.Object.Context = context.Object;
+
+            Mock<HttpResponse> response = new Mock<HttpResponse>();
+            response.Object.Context = context.Object;
+            response.Setup(v => v.Send()).Callback(() => {});
+
+            // Act
+            middleware.AfterRequestReceived(listener, request.Object, response.Object);
+
+            // Assert
+            response.Object.StatusCode = HttpStatusCode.MovedPermanently;
+            response.Object.Headers[HttpHeaders.Location] = "https://localhost:8080";
+        }
+    }
+}

--- a/Paracord.Core.IntegrationTests/Middleware/HttpsRedirectMiddlewareTests.cs
+++ b/Paracord.Core.IntegrationTests/Middleware/HttpsRedirectMiddlewareTests.cs
@@ -64,7 +64,7 @@ namespace Paracord.Core.Tests.Middleware
         }
 
         [Fact]
-        public void HttpsRedirectMiddlewareContinuesGivenSingleSecurePrefixAndInsecureRequest()
+        public void HttpsRedirectMiddlewareRedirectsGivenSingleSecurePrefixAndInsecureRequest()
         {
             // Arrange
             HttpsRedirectMiddleware middleware = new HttpsRedirectMiddleware();
@@ -75,6 +75,57 @@ namespace Paracord.Core.Tests.Middleware
 
             Mock<HttpRequest> request = new Mock<HttpRequest>();
             request.Object.Context = context.Object;
+
+            Mock<HttpResponse> response = new Mock<HttpResponse>();
+            response.Object.Context = context.Object;
+            response.Setup(v => v.Send()).Callback(() => { });
+
+            // Act
+            middleware.AfterRequestReceived(listener, request.Object, response.Object);
+
+            // Assert
+            response.Object.StatusCode = HttpStatusCode.MovedPermanently;
+            response.Object.Headers[HttpHeaders.Location] = "https://localhost:8080";
+        }
+
+        [Fact]
+        public void HttpsRedirectMiddlewareContinuesGivenUpgradeInsecureRequestsHeaderOfZero()
+        {
+            // Arrange
+            HttpsRedirectMiddleware middleware = new HttpsRedirectMiddleware();
+            HttpListener listener = new HttpListener();
+            listener.Prefixes.Add("https://localhost:8080");
+
+            Mock<TestHttpContext> context = new Mock<TestHttpContext>(listener, ListenerPrefix.Parse("http://localhost:8080"));
+
+            Mock<HttpRequest> request = new Mock<HttpRequest>();
+            request.Object.Context = context.Object;
+            request.Object.Headers[HttpHeaders.UpgradeInsecureRequests] = "0";
+
+            Mock<HttpResponse> response = new Mock<HttpResponse>();
+            response.Object.Context = context.Object;
+            response.Setup(v => v.Send()).Callback(() => { });
+
+            // Act
+            middleware.AfterRequestReceived(listener, request.Object, response.Object);
+
+            // Assert
+            response.Object.StatusCode = HttpStatusCode.Ok;
+        }
+
+        [Fact]
+        public void HttpsRedirectMiddlewareRedirectsGivenUpgradeInsecureRequestsHeaderOfOne()
+        {
+            // Arrange
+            HttpsRedirectMiddleware middleware = new HttpsRedirectMiddleware();
+            HttpListener listener = new HttpListener();
+            listener.Prefixes.Add("https://localhost:8080");
+
+            Mock<TestHttpContext> context = new Mock<TestHttpContext>(listener, ListenerPrefix.Parse("http://localhost:8080"));
+
+            Mock<HttpRequest> request = new Mock<HttpRequest>();
+            request.Object.Context = context.Object;
+            request.Object.Headers[HttpHeaders.UpgradeInsecureRequests] = "1";
 
             Mock<HttpResponse> response = new Mock<HttpResponse>();
             response.Object.Context = context.Object;

--- a/Paracord.Core.IntegrationTests/Middleware/HttpsRedirectMiddlewareTests.cs
+++ b/Paracord.Core.IntegrationTests/Middleware/HttpsRedirectMiddlewareTests.cs
@@ -78,7 +78,7 @@ namespace Paracord.Core.Tests.Middleware
 
             Mock<HttpResponse> response = new Mock<HttpResponse>();
             response.Object.Context = context.Object;
-            response.Setup(v => v.Send()).Callback(() => {});
+            response.Setup(v => v.Send()).Callback(() => { });
 
             // Act
             middleware.AfterRequestReceived(listener, request.Object, response.Object);

--- a/Paracord.Core.IntegrationTests/Paracord.Core.IntegrationTests.csproj
+++ b/Paracord.Core.IntegrationTests/Paracord.Core.IntegrationTests.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Paracord.Core/Http/HttpContext.cs
+++ b/Paracord.Core/Http/HttpContext.cs
@@ -102,6 +102,20 @@ namespace Paracord.Shared.Models.Http
         }
 
         /// <summary>
+        /// Internal constructor, used for testing.
+        /// </summary>
+        protected HttpContext(HttpListener listener, ListenerPrefix listenerPrefix)
+        {
+            this.Listener = listener;
+            this.ListenerPrefix = listenerPrefix;
+
+            this.Client = default!;
+            this.PlainStream = default!;
+            this.RequestStream = default!;
+            this.ResponseStream = default!;
+        }
+
+        /// <summary>
         /// Create a new <see cref="HttpContext" />-instance with the <paramref name="client" />.
         /// </summary>
         /// <param name="listener">The <see cref="HttpListener" />-instance which handles this context.</param>

--- a/Paracord.Core/Http/HttpResponse.cs
+++ b/Paracord.Core/Http/HttpResponse.cs
@@ -71,7 +71,7 @@ namespace Paracord.Core.Http
         }
 
         /// <inheritdoc cref="HttpContext.Send" />
-        public void Send()
+        public virtual void Send()
             => this.Context.Send();
 
         /// <summary>

--- a/Paracord.Core/Listener/ListenerBase.cs
+++ b/Paracord.Core/Listener/ListenerBase.cs
@@ -92,10 +92,13 @@ namespace Paracord.Core.Listener
 
             foreach(ListenerPrefix prefix in this.Prefixes)
             {
-                IPAddress address = IPAddress.Parse(prefix.Address);
-                int port = (int) prefix.Port;
+                IPAddress[] addresses = Dns.GetHostAddresses(prefix.Address);
+                if(addresses.Length == 0)
+                {
+                    throw new ArgumentException($"Prefix has invalid DNS entry: {prefix.Address}");
+                }
 
-                this.Listeners.Add(prefix, new TcpListener(address, port));
+                this.Listeners.Add(prefix, new TcpListener(addresses[0], (int) prefix.Port));
             }
 
             this.IsOpen = true;

--- a/Paracord.Core/Middleware/HttpsRedirectMiddleware.cs
+++ b/Paracord.Core/Middleware/HttpsRedirectMiddleware.cs
@@ -26,6 +26,18 @@ namespace Paracord.Core.Middleware
                 return;
             }
 
+            // If the client explicitly refuses to upgrade, skip.
+            if(request.Headers[HttpHeaders.UpgradeInsecureRequests] == "0")
+            {
+                this.Next();
+                return;
+            }
+
+            if(request.Headers[HttpHeaders.UpgradeInsecureRequests] == "1")
+            {
+                response.Headers[HttpHeaders.Vary] += HttpHeaders.UpgradeInsecureRequests;
+            }
+
             response.StatusCode = HttpStatusCode.MovedPermanently;
             response.Headers[HttpHeaders.Location] = listener.Prefixes.First(v => v.Secure).ToString();
             response.Send();

--- a/Paracord.Core/Middleware/HttpsRedirectMiddleware.cs
+++ b/Paracord.Core/Middleware/HttpsRedirectMiddleware.cs
@@ -1,0 +1,34 @@
+using Paracord.Core.Http;
+using Paracord.Core.Listener;
+using Paracord.Shared.Models.Http;
+
+namespace Paracord.Core.Middleware
+{
+    /// <summary>
+    /// This middleware handles automatic redirection from HTTP to HTTPS.
+    /// </summary>
+    public class HttpsRedirectMiddleware : MiddlewareBase
+    {
+        public override void AfterRequestReceived(HttpListener listener, HttpRequest request, HttpResponse response)
+        {
+            bool hasSecurePrefix = listener.Prefixes.Any(v => v.Secure);
+            bool isRequestSecure = request.Context.ListenerPrefix.Secure;
+
+            if(!hasSecurePrefix)
+            {
+                this.Next();
+                return;
+            }
+
+            if(isRequestSecure)
+            {
+                this.Next();
+                return;
+            }
+
+            response.StatusCode = HttpStatusCode.MovedPermanently;
+            response.Headers[HttpHeaders.Location] = listener.Prefixes.First(v => v.Secure).ToString();
+            response.Send();
+        }
+    }
+}

--- a/Paracord.Core/Paracord.Core.csproj
+++ b/Paracord.Core/Paracord.Core.csproj
@@ -18,6 +18,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Paracord.Core.UnitTests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Paracord.Core.IntegrationTests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/Paracord.Shared.UnitTests/Models/Listener/HttpListenerPrefix/TryParseTests.cs
+++ b/Paracord.Shared.UnitTests/Models/Listener/HttpListenerPrefix/TryParseTests.cs
@@ -105,19 +105,6 @@ namespace Paracord.Shared.Tests.Listener.ListenerPrefixTests
         }
 
         [Fact]
-        public void TryParseReturnsFalseGivenProtocolWithoutSeparater()
-        {
-            // Arrange
-            string value = "https";
-
-            // Act
-            bool parsed = ListenerPrefix.TryParse(value, out var _);
-
-            // Assert
-            parsed.Should().BeFalse();
-        }
-
-        [Fact]
         public void TryParseReturnsTrueGivenAddressAndPort()
         {
             // Arrange

--- a/Paracord.Shared/Models/Listener/ListenerPrefix.cs
+++ b/Paracord.Shared/Models/Listener/ListenerPrefix.cs
@@ -87,7 +87,7 @@ namespace Paracord.Shared.Models.Listener
 
             address = address.Trim();
 
-            Regex pattern = new Regex(@"^((?<protocol>[a-zA-Z]+):\/\/)?(?<address>(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))(:(?<port>(\d+)))?$");
+            Regex pattern = new Regex(@"^((?<protocol>[a-zA-Z]+):\/\/)?(?<address>([A-Za-z0-9\.-]+))(:(?<port>(\d+)))?$");
             Match match = pattern.Match(address);
 
             if(!match.Success)


### PR DESCRIPTION
Add the ability to automatically redirect from HTTP to HTTPS, given certain criteria:
- A secure prefix is available
- The request was made with an insecure prefix
- "Upgrade-Insecure-Requests" is either unset or set to 1.